### PR TITLE
Update PPA to new unifi address

### DIFF
--- a/recipes/ppa.rb
+++ b/recipes/ppa.rb
@@ -10,9 +10,8 @@
 
 
 apt_repository 'ubiquiti_unifi' do
-  uri 'http://www.ubnt.com/downloads/unifi/distros/deb/ubuntu'
-  distribution 'ubuntu'  # yes, it's generic.
-  components ['ubiquiti']
+  uri 'http://www.ubnt.com/downloads/unifi/debian'
+  components ['stable', 'ubiquiti']
   keyserver 'keyserver.ubuntu.com'
   key 'C0A52C50'
 end


### PR DESCRIPTION
Updating the PPA Address to be the new one as detailed in http://community.ubnt.com/t5/UniFi-Wireless/Updated-UniFi-Repo-info-APT-howto/m-p/1288883/highlight/true#M110117
