### PR TITLE
update ppa recipe to take apt components from an attribute for easier updating

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,12 @@
 #   BONUS: You can install / switch between them!
 #
 default['unifi']['package'] = 'unifi'
+
+#
+# Specify the apt components
+#   There are three available
+#     - unifi4/stable  (Unifi version 4.x.x)
+#     - unifi5         (Unifi version 5.x.x)
+#     - unifi3         (Unifi version 3.x.x)
+#
+default['unifi']['apt_components'] = %w(stable ubiquiti)

--- a/recipes/ppa.rb
+++ b/recipes/ppa.rb
@@ -10,7 +10,7 @@
 
 apt_repository 'ubiquiti_unifi' do
   uri 'http://www.ubnt.com/downloads/unifi/debian'
-  components %w(stable ubiquiti)
+  components node['unifi']['apt_components']
   distribution nil
   keyserver 'keyserver.ubuntu.com'
   key 'C0A52C50'


### PR DESCRIPTION
### Description

This changes the apt components to be a overridable attribute for easier updating to unifi5
### Issues Resolved

N/A
